### PR TITLE
Add UserCreate and UserEnableKeyAuth commands

### DIFF
--- a/bin/droid-user
+++ b/bin/droid-user
@@ -1,0 +1,30 @@
+#!/usr/bin/env php
+<?php
+
+use Symfony\Component\Console\Application;
+
+use Droid\Plugin\User\DroidPlugin;
+
+$loader = __DIR__ . '/../vendor/autoload.php';
+
+if (!file_exists($loader)) {
+    $loader = __DIR__ . '/../../../autoload.php';
+}
+
+if (!file_exists($loader)) {
+    die(
+        'You must set up the project dependencies, run the following commands:' . PHP_EOL .
+        'curl -s http://getcomposer.org/installer | php' . PHP_EOL .
+        'php composer.phar install' . PHP_EOL
+    );
+}
+
+require $loader;
+
+$application = new Application('Droid User', '1.0.0');
+$application->setCatchExceptions(true);
+$registry = new DroidPlugin($application);
+foreach ($registry->getCommands() as $command) {
+    $application->add($command);
+}
+$application->run();

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8",
+        "mikey179/vfsStream": "^1.6",
         "linkorb/autotune": "~1.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,8 @@
     ],
     "require": {
         "php": ">=5.4.0",
+        "droid/libcommand": "~1.0",
+        "symfony/process": "^3.0",
         "symfony/console": "~2.7"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=5.4.0",
         "droid/libcommand": "~1.0",
-        "symfony/process": "^3.0",
+        "symfony/process": "~2.7|~3.0.0",
         "symfony/console": "~2.7"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -27,5 +27,8 @@
             "Droid\\Plugin\\User\\": "src/"
         }
     },
+    "bin": [
+        "bin/droid-user"
+    ],
     "license": "MIT"
 }

--- a/src/Command/UserCreateCommand.php
+++ b/src/Command/UserCreateCommand.php
@@ -34,6 +34,15 @@ class UserCreateCommand extends Command
                 InputArgument::REQUIRED,
                 'Create a user with this user name.'
             )
+            ->setHelp(
+                'This command should be run by a user allowed to execute `sudo adduser`'
+                . "\n"
+                . 'without being required to input a password. Somthing like the following'
+                . "\n"
+                . 'entry in a sudoers file should work:-'
+                . "\n"
+                . "    my_user\tALL = NOPASSWD: /usr/sbin/adduser"
+            )
         ;
         $this->configureCheckMode();
     }
@@ -104,7 +113,7 @@ class UserCreateCommand extends Command
         if ($this->checkMode()) {
             return;
         }
-        $p = $this->getProcess(array('adduser', $username));
+        $p = $this->getProcess(array('sudo', 'adduser', $username));
         if ($p->run()) {
             throw new RuntimeException(
                 trim($p->getErrorOutput()),

--- a/src/Command/UserCreateCommand.php
+++ b/src/Command/UserCreateCommand.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Droid\Plugin\User\Command;
+
+use RuntimeException;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Process\ProcessBuilder;
+
+use Droid\Lib\Plugin\Command\CheckableTrait;
+
+class UserCreateCommand extends Command
+{
+    use CheckableTrait;
+
+    private $processBuilder;
+
+    public function __construct(ProcessBuilder $builder, $name = null)
+    {
+        $this->processBuilder = $builder;
+        return parent::__construct($name);
+    }
+
+    public function configure()
+    {
+        $this
+            ->setName('user:create')
+            ->setDescription('Add a Unix user account.')
+            ->addArgument(
+                'username',
+                InputArgument::REQUIRED,
+                'Create a user with this user name.'
+            )
+        ;
+        $this->configureCheckMode();
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->activateCheckMode($input);
+
+        $username = $input->getArgument('username');
+        if ($this->exists($username)) {
+            $output->writeLn(
+                sprintf(
+                    'I will not create user "%s" because one already exists with that name',
+                    $username
+                )
+            );
+            $this->reportChange($output);
+            return 1;
+        }
+
+        $this->markChange();
+
+        try {
+            $this->createUser($username);
+        } catch (RuntimeException $e) {
+            $output->writeLn(
+                sprintf(
+                    'I cannot create user "%s": %s',
+                    $username,
+                    $e->getMessage()
+                )
+            );
+            $this->reportChange($output);
+            return $e->getCode();
+        }
+
+        $output->writeLn(
+            sprintf(
+                'I %s a new user "%s".',
+                $this->checkMode() ? 'would create' : 'have created',
+                $username
+            )
+        );
+
+        $this->reportChange($output);
+        return 0;
+    }
+
+    private function getProcess($arguments)
+    {
+        return $this
+            ->processBuilder
+            ->setArguments($arguments)
+            ->getProcess()
+        ;
+    }
+
+    private function exists($username)
+    {
+        return 0 === $this
+            ->getProcess(array('id', $username))
+            ->run()
+        ;
+    }
+
+    private function createUser($username)
+    {
+        if ($this->checkMode()) {
+            return;
+        }
+        $p = $this->getProcess(array('adduser', $username));
+        if ($p->run()) {
+            throw new RuntimeException(
+                trim($p->getErrorOutput()),
+                $p->getExitCode()
+            );
+        }
+    }
+}

--- a/src/Command/UserEnableKeyAuthCommand.php
+++ b/src/Command/UserEnableKeyAuthCommand.php
@@ -1,0 +1,302 @@
+<?php
+
+namespace Droid\Plugin\User\Command;
+
+use RuntimeException;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Process\Process;
+
+use Droid\Lib\Plugin\Command\CheckableTrait;
+
+class UserEnableKeyAuthCommand extends Command
+{
+    use CheckableTrait;
+
+    const SSH_CLIENT_CONFDIR = '.ssh';
+    const SSH_CLIENT_AUTH_KEYFILE = 'authorized_keys';
+
+    public function configure()
+    {
+        $this
+            ->setName('user:enable-key-auth')
+            ->setDescription('Append ssh public keys to a user authorized_keys file.')
+            ->addArgument(
+                'pubkey',
+                InputArgument::REQUIRED,
+                'One or more lines of ssh public key data.'
+            )
+            ->addArgument(
+                'homedir',
+                InputArgument::REQUIRED,
+                'Path to the homedir of the user.'
+            )
+        ;
+        $this->configureCheckMode();
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->activateCheckMode($input);
+
+        // sane keys?
+        $candidatePubkeys = $this->validateKeys(
+            $this->preProcessKeys($input->getArgument('pubkey'))
+        );
+        if (!$candidatePubkeys) {
+            $output->writeLn(
+                'I cannot enable auth with the provided pubkeys because they are not well formed.'
+            );
+            $this->reportChange($output);
+            return 1;
+        }
+        $candidatePubkeyCount = sizeof($candidatePubkeys);
+
+        // sane homedir?
+        $homedir = $input->getArgument('homedir');
+        if (file_exists($homedir) === false || is_dir($homedir) === false) {
+            $output->writeLn(
+                sprintf(
+                    'I cannot enable auth because the homedir does not exist: "%s".',
+                    $homedir
+                )
+            );
+            $this->reportChange($output);
+            return 1;
+        }
+        if (is_readable($homedir) === false) {
+            $output->writeLn(
+                sprintf(
+                    'I cannot enable auth because the homedir is unreadable: "%s".',
+                    $homedir
+                )
+            );
+            $this->reportChange($output);
+            return 1;
+        }
+
+        // test for ~/.ssh/
+        $confdir = $homedir . DIRECTORY_SEPARATOR . self::SSH_CLIENT_CONFDIR;
+        if (file_exists($confdir) === false || is_dir($confdir) === false) {
+            $output->writeLn(
+                sprintf(
+                    'I cannot enable auth because the config directory does not exist: "%s".',
+                    $confdir
+                )
+            );
+            $this->reportChange($output);
+            return 1;
+        }
+        if (is_readable($confdir) === false) {
+            $output->writeLn(
+                sprintf(
+                    'I cannot enable auth because the config directory is unreadable: "%s".',
+                    $confdir
+                )
+            );
+            $this->reportChange($output);
+            return 1;
+        }
+
+        // authorized_keys must be readable, if it exists
+        $keysFile = $confdir . DIRECTORY_SEPARATOR . self::SSH_CLIENT_AUTH_KEYFILE;
+        if (file_exists($keysFile) && is_readable($keysFile) === false) {
+            $output->writeLn(
+                sprintf(
+                    'I cannot enable auth because the authorized_keys file is unreadable: "%s".',
+                    $keysFile
+                )
+            );
+            $this->reportChange($output);
+            return 1;
+        }
+
+        // get any existing authorized_keys
+        $existingKeys = null;
+        try {
+            $existingKeys = $this->readAuthdKeys($keysFile);
+        } catch (RuntimeException $e) {
+            $output->writeLn(
+                sprintf(
+                    'I cannot read existing authorized_keys at "%s": "%s".',
+                    $keysFile,
+                    $e->getMessage()
+                )
+            );
+            $this->reportChange($output);
+            return 1;
+        }
+
+        // filter out already authorized_keys
+        $keysToEnable = $candidatePubkeys;
+        if ($existingKeys) {
+            $keysToEnable = $this->filterKeys(
+                $candidatePubkeys,
+                $existingKeys
+            );
+            if (sizeof($keysToEnable) == 0) {
+                $singular = $candidatePubkeyCount == 1;
+                $output->writeLn(
+                    sprintf(
+                        'I have nothing to do: the %d public key%s supplied %s already enabled.',
+                        $candidatePubkeyCount,
+                        $singular ? '' : 's',
+                        $singular ? 'is' : 'are'
+                    )
+                );
+                $this->reportChange($output);
+                return 0;
+            } elseif (sizeof($keysToEnable) != $candidatePubkeyCount) {
+                $singular = ($candidatePubkeyCount - sizeof($keysToEnable)) == 1;
+                $output->writeLn(
+                    sprintf(
+                        'I will enable just %d of the %d supplied public keys because %d %s already enabled.',
+                        sizeof($keysToEnable),
+                        $candidatePubkeyCount,
+                        $candidatePubkeyCount - sizeof($keysToEnable),
+                        $singular ? 'is' : 'are'
+                    )
+                );
+            }
+        }
+
+        // write pubkeys
+        $this->markChange();
+        try {
+            $this->writeKeys($keysToEnable, $keysFile);
+        } catch (RuntimeException $e) {
+            $output->writeLn(
+                sprintf(
+                    'I cannot write the provided keys to "%s": "%s".',
+                    $keysFile,
+                    $e->getMessage()
+                )
+            );
+            $this->reportChange($output);
+            return 1;
+        }
+
+        $output->writeLn(
+            sprintf(
+                'I %s enabled auth for %d key%s.',
+                $this->checkMode() ? 'would have' : 'have successfully',
+                sizeof($keysToEnable),
+                sizeof($keysToEnable) == 1 ? '' : 's'
+            )
+        );
+
+        $this->reportChange($output);
+        return 0;
+    }
+
+    private function preProcessKeys($keyData)
+    {
+        if (empty($keyData)) {
+            return null;
+        }
+        return explode("\n", $keyData);
+    }
+
+    private function validateKeys($keys)
+    {
+        $valid = array();
+        foreach ($keys as $key) {
+            if (empty($key)) {
+                continue;
+            }
+            $parts = explode(' ', $key);
+            if (sizeof($parts) < 3) {
+                return null;
+            }
+            $label = array_shift($parts);
+            if (substr($label, 0, 4) !== 'ssh-') {
+                return null;
+            }
+            $valid[] = $key;
+        }
+        return $valid;
+    }
+
+    private function readAuthdKeys($path)
+    {
+        $data = file_get_contents($path);
+        if ($data === false) {
+            throw new RuntimeException(
+                sprintf('Failed to read the content of "%s".', $path)
+            );
+        }
+        return $data;
+    }
+
+    private function filterKeys($candidateKeys, $existingKeys)
+    {
+        // hash each existing key material
+        if (empty($existingKeys)) {
+            return $candidateKeys;
+        }
+        $hashmap = array();
+        foreach (explode("\n", $existingKeys) as $line) {
+            if (empty($line)) {
+                continue;
+            }
+            list(, $material, ) = explode(' ', $line);
+            $hashmap[hash('sha256', $material)] = true;
+        }
+        // drop candidates which their key material already exists
+        $filtered = array();
+        foreach ($candidateKeys as $candidate) {
+            list(,$material, ) = explode(' ', $candidate);
+            if (array_key_exists(hash('sha256', $material), $hashmap)) {
+                continue;
+            }
+            $filtered[] = $candidate;
+        }
+        return $filtered;
+    }
+
+    private function writeKeys($keys, $path)
+    {
+        if ($this->checkMode()) {
+            return;
+        }
+        $needsNewline = $this->needsInitialNewline($path);
+        $fh = fopen($path, 'a');
+        if ($fh == false) {
+            throw new RuntimeException(
+                sprintf('Failed to open "%s" for appending.', $path)
+            );
+        }
+        if ($needsNewline) {
+            fwrite($fh, "\n");
+        }
+        fwrite($fh, implode("\n", $keys));
+        fwrite($fh, "\n");
+        fclose($fh);
+    }
+
+    /*
+     * If the file exists, and definitely doesn't end in a newline.
+     */
+    private function needsInitialNewline($path)
+    {
+        $result = false;
+        if (! file_exists($path)) {
+            return $result;
+        }
+        $fh = fopen($path, 'r');
+        if ($fh === false) {
+            return $result;
+        }
+        if (fseek($fh, -1, SEEK_END) === 0) {
+            $lastChar = fgetc($fh);
+            if ($lastChar !== "\n" && $lastChar !== "\r") {
+                $result = true;
+            }
+        }
+        fclose($fh);
+        return $result;
+    }
+}

--- a/src/DroidPlugin.php
+++ b/src/DroidPlugin.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Droid\Plugin\User;
+
+use Symfony\Component\Process\ProcessBuilder;
+
+use Droid\Plugin\User\Command\UserCreateCommand;
+
+class DroidPlugin
+{
+    public function __construct($droid)
+    {
+        $this->droid = $droid;
+    }
+
+    public function getCommands()
+    {
+        return array(
+            new UserCreateCommand(new ProcessBuilder),
+        );
+    }
+}

--- a/src/DroidPlugin.php
+++ b/src/DroidPlugin.php
@@ -5,6 +5,7 @@ namespace Droid\Plugin\User;
 use Symfony\Component\Process\ProcessBuilder;
 
 use Droid\Plugin\User\Command\UserCreateCommand;
+use Droid\Plugin\User\Command\UserEnableKeyAuthCommand;
 
 class DroidPlugin
 {
@@ -17,6 +18,7 @@ class DroidPlugin
     {
         return array(
             new UserCreateCommand(new ProcessBuilder),
+            new UserEnableKeyAuthCommand,
         );
     }
 }

--- a/test/Command/UserCreateCommandTest.php
+++ b/test/Command/UserCreateCommandTest.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace Droid\Test\Plugin\User\Command;
+
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Process\Process;
+use Symfony\Component\Process\ProcessBuilder;
+
+use Droid\Plugin\User\Command\UserCreateCommand;
+
+class UserCreateCommandTest extends \PHPUnit_Framework_TestCase
+{
+    protected $app;
+    protected $process;
+    protected $processBuilder;
+
+    protected function setUp()
+    {
+        $this->process = $this
+            ->getMockBuilder(Process::class)
+            ->disableOriginalConstructor()
+            ->setMethods(array('run', 'getErrorOutput', 'getExitCode'))
+            ->getMock()
+        ;
+        $this->processBuilder = $this
+            ->getMockBuilder(ProcessBuilder::class)
+            ->setMethods(array('setArguments', 'getProcess'))
+            ->getMock()
+        ;
+
+        $command = new UserCreateCommand($this->processBuilder);
+
+        $this->app = new Application;
+        $this->app->add($command);
+    }
+
+    public function testCommandWillNotCreateUserIfExists()
+    {
+        $command = $this->app->find('user:create');
+
+        // simulate user exists
+        $this->processBuilder
+            ->expects($this->once())
+            ->method('setArguments')
+            ->with(array('id', 'some_username'))
+            ->willReturnSelf()
+        ;
+        $this->processBuilder
+            ->expects($this->once())
+            ->method('getProcess')
+            ->willReturn($this->process)
+        ;
+        $this->process
+            ->expects($this->once())
+            ->method('run')
+            ->willReturn(0)
+        ;
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(array(
+            'command' => $command->getName(),
+            'username' => 'some_username'
+        ));
+
+        $this->assertRegExp(
+            '/^I will not create user "some_username" because one already exists with that name/',
+            $commandTester->getDisplay()
+        );
+    }
+
+    public function testCommandFailsToCreateUser()
+    {
+        $command = $this->app->find('user:create');
+
+        // simulate user not exists and failed adduser
+        $this->processBuilder
+            ->expects($this->exactly(2))
+            ->method('setArguments')
+            ->withConsecutive(
+                array(array('id', 'some_username')),
+                array(array('adduser', 'some_username'))
+            )
+            ->willReturnSelf()
+        ;
+        $this->processBuilder
+            ->expects($this->exactly(2))
+            ->method('getProcess')
+            ->willReturn($this->process)
+        ;
+        $this->process
+            ->expects($this->exactly(2))
+            ->method('run')
+            ->willReturnOnConsecutiveCalls(1, 1)
+        ;
+        $this->process
+            ->expects($this->once())
+            ->method('getErrorOutput')
+            ->willReturn('because bad things happened')
+        ;
+        $this->process
+            ->expects($this->once())
+            ->method('getExitCode')
+            ->willReturn(1)
+        ;
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(array(
+            'command' => $command->getName(),
+            'username' => 'some_username'
+        ));
+
+        $this->assertRegExp(
+            '/^I cannot create user "some_username": because bad things happened/',
+            $commandTester->getDisplay()
+        );
+    }
+
+    public function testCommandWillNotCreateUserInCheckMode()
+    {
+        $command = $this->app->find('user:create');
+
+        // simulate user not exists and successful adduser
+        $this->processBuilder
+            ->expects($this->once())
+            ->method('setArguments')
+            ->with(array('id', 'some_username'))
+            ->willReturnSelf()
+        ;
+        $this->processBuilder
+            ->expects($this->once())
+            ->method('getProcess')
+            ->willReturn($this->process)
+        ;
+        $this->process
+            ->expects($this->once())
+            ->method('run')
+            ->willReturn(1)
+        ;
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(array(
+            'command' => $command->getName(),
+            'username' => 'some_username',
+            '--check' => true,
+        ));
+
+        $this->assertRegExp(
+            '/^I would create a new user "some_username"/',
+            $commandTester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/\[DROID\-RESULT\].*"changed":true/',
+            $commandTester->getDisplay()
+        );
+    }
+
+    public function testCommandWillCreateUser()
+    {
+        $command = $this->app->find('user:create');
+
+        // simulate user not exists and successful adduser
+        $this->processBuilder
+            ->expects($this->exactly(2))
+            ->method('setArguments')
+            ->withConsecutive(
+                array(array('id', 'some_username')),
+                array(array('adduser', 'some_username'))
+            )
+            ->willReturnSelf()
+        ;
+        $this->processBuilder
+            ->expects($this->exactly(2))
+            ->method('getProcess')
+            ->willReturn($this->process)
+        ;
+        $this->process
+            ->expects($this->exactly(2))
+            ->method('run')
+            ->willReturnOnConsecutiveCalls(1, 0)
+        ;
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(array(
+            'command' => $command->getName(),
+            'username' => 'some_username'
+        ));
+
+        $this->assertRegExp(
+            '/^I have created a new user "some_username"/',
+            $commandTester->getDisplay()
+        );
+    }
+}

--- a/test/Command/UserCreateCommandTest.php
+++ b/test/Command/UserCreateCommandTest.php
@@ -79,7 +79,7 @@ class UserCreateCommandTest extends \PHPUnit_Framework_TestCase
             ->method('setArguments')
             ->withConsecutive(
                 array(array('id', 'some_username')),
-                array(array('adduser', 'some_username'))
+                array(array('sudo', 'adduser', 'some_username'))
             )
             ->willReturnSelf()
         ;
@@ -166,7 +166,7 @@ class UserCreateCommandTest extends \PHPUnit_Framework_TestCase
             ->method('setArguments')
             ->withConsecutive(
                 array(array('id', 'some_username')),
-                array(array('adduser', 'some_username'))
+                array(array('sudo', 'adduser', 'some_username'))
             )
             ->willReturnSelf()
         ;

--- a/test/Command/UserEnableKeyAuthCommandTest.php
+++ b/test/Command/UserEnableKeyAuthCommandTest.php
@@ -1,0 +1,309 @@
+<?php
+
+namespace Droid\Test\Plugin\User\Command;
+
+use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Process\Process;
+use Symfony\Component\Process\ProcessBuilder;
+
+use Droid\Plugin\User\Command\UserEnableKeyAuthCommand;
+
+class UserEnableKeyAuthCommandTest extends \PHPUnit_Framework_TestCase
+{
+    protected $app;
+    protected $vfs;
+    protected $tester;
+    protected $process;
+    protected $processBuilder;
+
+    protected function setUp()
+    {
+        $this->process = $this
+            ->getMockBuilder(Process::class)
+            ->disableOriginalConstructor()
+            ->setMethods(array('run', 'getErrorOutput', 'getExitCode'))
+            ->getMock()
+        ;
+        $this->processBuilder = $this
+            ->getMockBuilder(ProcessBuilder::class)
+            ->setMethods(array('setArguments', 'getProcess'))
+            ->getMock()
+        ;
+
+        // Note that, for testing purposes, this is the root directory and all
+        // paths begin 'home', not '/home'.
+        $this->vfs = vfsStream::setup('home');
+
+        $command = new UserEnableKeyAuthCommand;
+
+        $this->app = new Application;
+        $this->app->add($command);
+        $this->tester = new CommandTester($command);
+    }
+
+    public function testCommandFailsWhenKeysAreMalformed()
+    {
+        $this->tester->execute(array(
+            'command' => $this->app->find('user:enable-key-auth')->getName(),
+            'homedir' => vfsStream::url('home/some_username'),
+            'pubkey' => 'sh-rsa some_key_material and a comment'
+        ));
+
+        $this->assertRegExp(
+            '/^I cannot enable auth with the provided pubkeys because they are not well formed/',
+            $this->tester->getDisplay()
+        );
+    }
+
+    public function testCommandFailsWhenUserHomedirIsMissing()
+    {
+        $this->tester->execute(array(
+            'command' => $this->app->find('user:enable-key-auth')->getName(),
+            'homedir' => vfsStream::url('home/some_username'),
+            'pubkey' => 'ssh-rsa some_key_material and a comment'
+        ));
+
+        $this->assertFalse($this->vfs->hasChild('some_username'));
+        $this->assertRegExp(
+            '/^I cannot enable auth because the homedir does not exist: "[^"]*"/',
+            $this->tester->getDisplay()
+        );
+    }
+
+    public function testCommandFailsWhenUserHomedirIsNotADirectory()
+    {
+        $this->vfs->addChild(vfsStream::newFile('some_username'));
+
+        $this->tester->execute(array(
+            'command' => $this->app->find('user:enable-key-auth')->getName(),
+            'homedir' => vfsStream::url('home/some_username'),
+            'pubkey' => 'ssh-rsa some_key_material and a comment'
+        ));
+
+        $this->assertTrue($this->vfs->hasChild('some_username'));
+        $this->assertRegExp(
+            '/^I cannot enable auth because the homedir does not exist: "[^"]*"/',
+            $this->tester->getDisplay()
+        );
+    }
+
+    public function testCommandFailsWhenUserHomedirIsUnreadable()
+    {
+        $this->vfs->addChild(vfsStream::newDirectory('some_username', 0100));
+
+        $this->tester->execute(array(
+            'command' => $this->app->find('user:enable-key-auth')->getName(),
+            'homedir' => vfsStream::url('home/some_username'),
+            'pubkey' => 'ssh-rsa some_key_material and a comment'
+        ));
+
+        $this->assertTrue($this->vfs->hasChild('some_username'));
+        $this->assertRegExp(
+            '/^I cannot enable auth because the homedir is unreadable: "[^"]*"/',
+            $this->tester->getDisplay()
+        );
+    }
+
+    public function testCommandFailsWhenUserSshConfigDirIsMissing()
+    {
+        $this->vfs->addChild(vfsStream::newDirectory('some_username'));
+
+        $this->tester->execute(array(
+            'command' => $this->app->find('user:enable-key-auth')->getName(),
+            'homedir' => vfsStream::url('home/some_username'),
+            'pubkey' => 'ssh-rsa some_key_material and a comment'
+        ));
+
+        $this->assertTrue($this->vfs->hasChild('some_username'));
+        $this->assertFalse($this->vfs->getChild('some_username')->hasChild('.ssh'));
+        $this->assertRegExp(
+            '/^I cannot enable auth because the config directory does not exist: "[^"]*"/',
+            $this->tester->getDisplay()
+        );
+    }
+
+    public function testCommandFailsWhenUserSshConfigDirIsNotADirectory()
+    {
+        vfsStream::create(array('some_username' => array()));
+        $this
+            ->vfs
+            ->getChild('some_username')
+            ->addChild(vfsStream::newFile('.ssh'))
+        ;
+
+        $this->tester->execute(array(
+            'command' => $this->app->find('user:enable-key-auth')->getName(),
+            'homedir' => vfsStream::url('home/some_username'),
+            'pubkey' => 'ssh-rsa some_key_material and a comment'
+        ));
+
+        $this->assertTrue($this->vfs->getChild('some_username')->hasChild('.ssh'));
+        $this->assertRegExp(
+            '/^I cannot enable auth because the config directory does not exist: "[^"]*"/',
+            $this->tester->getDisplay()
+        );
+    }
+
+    public function testCommandFailsWhenUserSshConfigDirIsUnreadable()
+    {
+        vfsStream::create(array('some_username' => array()));
+        $this
+            ->vfs
+            ->getChild('some_username')
+            ->addChild(vfsStream::newDirectory('.ssh', 0100))
+        ;
+
+        $this->tester->execute(array(
+            'command' => $this->app->find('user:enable-key-auth')->getName(),
+            'homedir' => vfsStream::url('home/some_username'),
+            'pubkey' => 'ssh-rsa some_key_material and a comment'
+        ));
+
+        $this->assertTrue($this->vfs->getChild('some_username')->hasChild('.ssh'));
+        $this->assertRegExp(
+            '/^I cannot enable auth because the config directory is unreadable: "[^"]*"/',
+            $this->tester->getDisplay()
+        );
+    }
+
+    public function testCommandFailsWhenUserAuthorizedKeysIsUnreadable()
+    {
+        vfsStream::create(array('some_username' => array('.ssh' => array())));
+        $sshDir = $this->vfs->getChild('some_username')->getChild('.ssh');
+        $sshDir->addChild(vfsStream::newFile('authorized_keys', 0100));
+
+        $this->tester->execute(array(
+            'command' => $this->app->find('user:enable-key-auth')->getName(),
+            'homedir' => vfsStream::url('home/some_username'),
+            'pubkey' => 'ssh-rsa some_key_material and a comment'
+        ));
+
+        $this->assertTrue($sshDir->hasChild('authorized_keys'));
+        $this->assertRegExp(
+            '/^I cannot enable auth because the authorized_keys file is unreadable: "[^"]*"/',
+            $this->tester->getDisplay()
+        );
+    }
+
+    public function testCommandWillNotAddExistingKeys()
+    {
+        vfsStream::create(array('some_username' => array('.ssh' => array())));
+        $sshDir = $this->vfs->getChild('some_username')->getChild('.ssh');
+        vfsStream::newFile('authorized_keys')
+            ->at($sshDir)
+            ->setContent('ssh-rsa some_key_material and a comment')
+        ;
+
+        $this->tester->execute(array(
+            'command' => $this->app->find('user:enable-key-auth')->getName(),
+            'homedir' => vfsStream::url('home/some_username'),
+            'pubkey' => 'ssh-rsa some_key_material and a different comment'
+        ));
+
+        $this->assertSame(
+            'ssh-rsa some_key_material and a comment',
+            $sshDir->getChild('authorized_keys')->getContent()
+        );
+        $this->assertRegExp(
+            '/^I have nothing to do: the 1 public key supplied is already enabled./',
+            $this->tester->getDisplay()
+        );
+    }
+
+    public function testCommandFailsWhenUserAuthorizedKeysIsUnwritable()
+    {
+        vfsStream::create(array('some_username' => array('.ssh' => array())));
+        $sshDir = $this->vfs->getChild('some_username')->getChild('.ssh');
+        $sshDir->addChild(vfsStream::newFile('authorized_keys', 0400));
+
+        $this->tester->execute(array(
+            'command' => $this->app->find('user:enable-key-auth')->getName(),
+            'homedir' => vfsStream::url('home/some_username'),
+            'pubkey' => 'ssh-rsa some_key_material and a comment'
+        ));
+
+        $this->assertRegExp(
+            '/^I cannot write the provided keys to "[^"]*": "[^"]*"./',
+            $this->tester->getDisplay()
+        );
+    }
+
+    public function testCommandWillAddSingleKey()
+    {
+        vfsStream::create(array('some_username' => array('.ssh' => array())));
+        $sshDir = $this->vfs->getChild('some_username')->getChild('.ssh');
+        vfsStream::newFile('authorized_keys')
+            ->at($sshDir)
+            ->setContent('ssh-rsa some_key_material and a comment')
+        ;
+
+        $this->tester->execute(array(
+            'command' => $this->app->find('user:enable-key-auth')->getName(),
+            'homedir' => vfsStream::url('home/some_username'),
+            'pubkey' => 'ssh-rsa some_other_key_material and a comment'
+        ));
+
+        $this->assertSame(
+            implode(
+                "\n",
+                array(
+                    'ssh-rsa some_key_material and a comment',
+                    'ssh-rsa some_other_key_material and a comment',
+                    '',
+                )
+            ),
+            $sshDir->getChild('authorized_keys')->getContent()
+        );
+        $this->assertRegExp(
+            '/^I have successfully enabled auth for 1 key./',
+            $this->tester->getDisplay()
+        );
+    }
+
+    public function testCommandWillAddMultipleKeys()
+    {
+        vfsStream::create(array('some_username' => array('.ssh' => array())));
+        $sshDir = $this->vfs->getChild('some_username')->getChild('.ssh');
+        vfsStream::newFile('authorized_keys')
+            ->at($sshDir)
+            ->setContent('ssh-rsa some_key_material and a comment')
+        ;
+
+        $this->tester->execute(array(
+            'command' => $this->app->find('user:enable-key-auth')->getName(),
+            'homedir' => vfsStream::url('home/some_username'),
+            'pubkey' => implode(
+                "\n",
+                array(
+                    'ssh-rsa some_key_material and a comment',
+                    'ssh-rsa some_other_key_material and a comment',
+                    'ssh-ed2219 even_more_key_material and a comment',
+                )
+            )
+        ));
+
+        $this->assertSame(
+            implode(
+                "\n",
+                array(
+                    'ssh-rsa some_key_material and a comment',
+                    'ssh-rsa some_other_key_material and a comment',
+                    'ssh-ed2219 even_more_key_material and a comment',
+                    '',
+                )
+            ),
+            $sshDir->getChild('authorized_keys')->getContent()
+        );
+        $this->assertRegExp(
+            '/^I will enable just 2 of the 3 supplied public keys because 1 is already enabled./',
+            $this->tester->getDisplay()
+        );
+        $this->assertRegExp(
+            '/I have successfully enabled auth for 2 keys./',
+            $this->tester->getDisplay()
+        );
+    }
+}


### PR DESCRIPTION
For review.

```
phpunit --testdox

Droid\Test\Plugin\User\Command\UserCreateCommand
 [x] Command will not create user if exists
 [x] Command fails to create user
 [x] Command will not create user in check mode
 [x] Command will create user

Droid\Test\Plugin\User\Command\UserEnableKeyAuthCommand
 [x] Command fails when keys are malformed
 [x] Command fails when user homedir is missing
 [x] Command fails when user homedir is not a directory
 [x] Command fails when user homedir is unreadable
 [x] Command fails when user ssh config dir is missing
 [x] Command fails when user ssh config dir is not a directory
 [x] Command fails when user ssh config dir is unreadable
 [x] Command fails when user authorized keys is unreadable
 [x] Command will not add existing keys
 [x] Command fails when user authorized keys is unwritable
 [x] Command will add single key
 [x] Command will add multiple keys
```
